### PR TITLE
Warning for ties in stats

### DIFF
--- a/R/fgsea.R
+++ b/R/fgsea.R
@@ -137,7 +137,7 @@ fgsea <- function(pathways, stats, nperm,
   
     #Warning message for ties in stats
     ties <- (length(stats[stats!=0])-length(unique(stats[stats!=0])))!=0
-    if (ties == T){ message("There are ties in the preranked stats (",paste(round(length(stats[duplicated(stats[stats!=0])])*100/length(stats),digits = 2)),"% of the list).\n",
+    if (ties == T){ warning("There are ties in the preranked stats (",paste(round(length(stats[duplicated(stats[stats!=0])])*100/length(stats),digits = 2)),"% of the list).\n",
                             "The order of those tied genes will be arbitrary, which may produce unexpected results.")}
 
     granularity <- 1000

--- a/R/fgsea.R
+++ b/R/fgsea.R
@@ -134,6 +134,11 @@ fgsea <- function(pathways, stats, nperm,
                   nproc=0,
                   gseaParam=1,
                   BPPARAM=NULL) {
+  
+    #Warning message for ties in stats
+    ties <- (length(stats[stats!=0])-length(unique(stats[stats!=0])))!=0
+    if (ties == T){ message("There are ties in the preranked stats (",paste(round(length(stats[duplicated(stats[stats!=0])])*100/length(stats),digits = 2)),"% of the list).\n",
+                            "The order of those tied genes will be arbitrary, which may produce unexpected results.")}
 
     granularity <- 1000
     permPerProc <- rep(granularity, floor(nperm / granularity))

--- a/tests/testthat/test_gsea_analysis.R
+++ b/tests/testthat/test_gsea_analysis.R
@@ -75,3 +75,18 @@ test_that("fgseaLabel works", {
     fgseaRes <- fgseaLabel(pathways, mat, labels, nperm = 1000, minSize = 15, maxSize = 500)
 
 })
+
+test_that("Ties detection in ranking works",{
+    data(examplePathways)
+    data(exampleRanks)
+    exampleRanks.ties <- exampleRanks
+    name20<- names(exampleRanks.ties[42])
+    exampleRanks.ties[41] <- exampleRanks.ties[42]
+    names(exampleRanks.ties[41])<-name20
+
+    expect_silent(fgsea(examplePathways, exampleRanks, nperm=100,minSize=50, maxSize=10,nproc = 1))
+    
+    expect_warning( fgsea(examplePathways, exampleRanks.ties, nperm=100,minSize=50, maxSize=10,nproc = 1))
+
+
+    })


### PR DESCRIPTION
**Print a message if there are ties in the metric and the percentage of it.**

@assaron,

Due to the previous discussion about ties (#18) and never ending analysis (#19), I put some changes to include a warning for the presence of ties in the stats:  

- This only for metric not equal to zero, as changing the order of genes equal to 0 it is no relevant.    
- I do not know which percentage of ties are aceptable, this is still open.    
- Ties shouldn't impact in the biological interpretation of the results. But the user should be aware of this when they are doing the analysis. As discussed in #18 and #19.

Best,
ToledoEM