### PR TITLE
Add some input checks

### DIFF
--- a/R/fgsea.R
+++ b/R/fgsea.R
@@ -134,6 +134,16 @@ fgsea <- function(pathways, stats, nperm,
                   nproc=0,
                   gseaParam=1,
                   BPPARAM=NULL) {
+  
+    # Error if pathways is not a list
+    if (!is.list(pathways)) {
+        stop("pathways should be a list with each element containing names of the stats argument")
+    }
+    
+    # Error if stats is not named
+    if (!is.null(names(stats))) {
+        stop("stats should be named")
+    }
 
     # Warning message for ties in stats
     ties <- sum(duplicated(stats[stats != 0]))


### PR DESCRIPTION
I added input checks to fgsea to check the type of `pathways` and the names of `stats`. Perhaps this checks should be also replicated in some other functions. 
The history is that after some time without using, I tried using fgsea and I got some strange errors, then I found the root to be my faulty input. 

However, this PR doesn't tests (or there are few tests that check the validity of the input). 

Let me know if you want further improvements on the PR (although I don't know when I will be able to implement them).