### PR TITLE
Add option to plotGseaTable to return plot

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -7,6 +7,8 @@
 #'      choice too.
 #' @param colwidths Vector of five elements corresponding to column width for
 #'      grid.arrange. If column width is set to zero, the column is not drawn.
+#' @param render If true, the plot is rendered to the current device.
+#'      Otherwise, the grob is returned. Default is true.
 #' @return TableGrob object returned by grid.arrange.
 #' @import ggplot2
 #' @import gridExtra
@@ -24,7 +26,8 @@
 #' }
 plotGseaTable <- function(pathways, stats, fgseaRes,
                           gseaParam=1,
-                          colwidths=c(5, 3, 0.8, 1.2, 1.2)) {
+                          colwidths=c(5, 3, 0.8, 1.2, 1.2),
+                          render=TRUE) {
 
     rnk <- rank(-stats)
     ord <- order(rnk)
@@ -98,9 +101,15 @@ plotGseaTable <- function(pathways, stats, fgseaRes,
     grobsToDraw <- rep(colwidths != 0, length(grobs)/length(colwidths))
 
 
-    grid.arrange(grobs=grobs[grobsToDraw],
+    p <- arrangeGrob(grobs=grobs[grobsToDraw],
                  ncol=sum(colwidths != 0),
                  widths=colwidths[colwidths != 0])
+
+    if (render) {
+        grid.draw(p)
+    } else {
+        p
+    }
 }
 
 #' Plots GSEA enrichment plot.


### PR DESCRIPTION
The previous behavior of plotGseaTable is to call grid.arrange, which renders to the current output device, unlike plotEnrichment which returns a plot. By calling arrangeGrob() when `render = FALSE`, we return an object which can be manually rendered later by the caller by calling grid.draw. This enables the output of plotGseaTable to be stored into a variable and displayed later.

This change allows the caller to work around the issue raised in #42.