### PR TITLE
Adding fold enrichment score to fora() output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fgsea
 Title: Fast Gene Set Enrichment Analysis
-Version: 1.31.1
+Version: 1.31.2
 Authors@R: c(person("Gennady", "Korotkevich", role = "aut"),
              person("Vladimir", "Sukhov", role = "aut"),
              person("Nikolay", "Budin", role = "ctb"),
@@ -41,7 +41,7 @@ Suggests:
 License: MIT + file LICENCE
 LazyData: true
 LinkingTo: Rcpp, BH
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 Encoding: UTF-8
 VignetteBuilder: knitr
 URL: https://github.com/ctlab/fgsea/

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+CHANGES IN VERSION 1.31.2
+* fora() provides fold enrichment scores for more effective prioritisation of results
+
 CHANGES IN VERSION 1.25.1
 * introduced plotEnrichmentData() function for more flexible plotting
 * update GESECA plot behavior

--- a/R/fgseaORA.R
+++ b/R/fgseaORA.R
@@ -10,6 +10,7 @@
 #'  \item pathway -- name of the pathway as in `names(pathway)`;
 #'  \item pval -- an enrichment p-value from hypergeometric test;
 #'  \item padj -- a BH-adjusted p-value;
+#'  \item foldEnrichment -- degree of enrichment relative to background;
 #'  \item overlap -- size of the overlap;
 #'  \item size -- size of the gene set;
 #'  \item leadingEdge -- vector with overlapping genes.
@@ -43,6 +44,7 @@ fora <- function(pathways, genes, universe, minSize=1, maxSize=length(universe)-
         return(data.table(pathway=character(),
                           pval=numeric(),
                           padj=numeric(),
+                          foldEnrichment=numeric(),
                           overlap=integer(),
                           size=integer(),
                           overlapGenes=list()))
@@ -65,7 +67,9 @@ fora <- function(pathways, genes, universe, minSize=1, maxSize=length(universe)-
         q=sapply(overlaps, length),
         m=sapply(pathwaysFiltered, length),
         n=length(universe)-sapply(pathwaysFiltered, length),
-        k=length(genesFiltered))
+        k=length(genesFiltered),
+        es=(q/k)/(m/length(universe)))
+
 
     # q-1 because we want probability of having >=q white balls
     pathways.pvals <- with(overlapsT,
@@ -74,6 +78,7 @@ fora <- function(pathways, genes, universe, minSize=1, maxSize=length(universe)-
     res <- data.table(pathway=names(pathwaysFiltered),
                       pval=pathways.pvals,
                       padj=p.adjust(pathways.pvals, method="BH"),
+                      foldEnrichment=T$es,
                       overlap=overlapsT$q,
                       size=overlapsT$m,
                       overlapGenes=overlapGenes)

--- a/R/fgseaORA.R
+++ b/R/fgseaORA.R
@@ -67,9 +67,9 @@ fora <- function(pathways, genes, universe, minSize=1, maxSize=length(universe)-
         q=sapply(overlaps, length),
         m=sapply(pathwaysFiltered, length),
         n=length(universe)-sapply(pathwaysFiltered, length),
-        k=length(genesFiltered),
-        es=(q/k)/(m/length(universe)))
+        k=length(genesFiltered))
 
+    overlapsT$es=(overlapsT$q/overlapsT$k)/(overlapsT$m/length(universe))
 
     # q-1 because we want probability of having >=q white balls
     pathways.pvals <- with(overlapsT,
@@ -78,7 +78,7 @@ fora <- function(pathways, genes, universe, minSize=1, maxSize=length(universe)-
     res <- data.table(pathway=names(pathwaysFiltered),
                       pval=pathways.pvals,
                       padj=p.adjust(pathways.pvals, method="BH"),
-                      foldEnrichment=T$es,
+                      foldEnrichment=overlapsT$es,
                       overlap=overlapsT$q,
                       size=overlapsT$m,
                       overlapGenes=overlapGenes)

--- a/man/fora.Rd
+++ b/man/fora.Rd
@@ -24,6 +24,7 @@ The columns are the following:
  \item pathway -- name of the pathway as in `names(pathway)`;
  \item pval -- an enrichment p-value from hypergeometric test;
  \item padj -- a BH-adjusted p-value;
+ \item foldEnrichment -- degree of enrichment relative to background;
  \item overlap -- size of the overlap;
  \item size -- size of the gene set;
  \item leadingEdge -- vector with overlapping genes.


### PR DESCRIPTION
Fold enrichment score is a useful surrogate for effect size. Both padj and fold enrichment score should be used when prioritising pathway enrichment results. I have included `foldEnrichment` in the `fora()` ouput. 