### PR TITLE
Issue 150 plotCoregulationSpatial

### DIFF
--- a/R/geseca-plot.R
+++ b/R/geseca-plot.R
@@ -293,7 +293,7 @@ plotCoregulationProfileSpatial <- function(pathway,
     }
 
 
-    obj2 <- fgsea:::addGesecaScores(list(pathway = pathway), object,
+    obj2 <- addGesecaScores(list(pathway = pathway), object,
                                     assay = assay, scale = TRUE)
     ps <- Seurat::SpatialFeaturePlot(obj2, features = "pathway",
                                      combine = FALSE, image.alpha = 0, ...)

--- a/R/geseca-plot.R
+++ b/R/geseca-plot.R
@@ -267,7 +267,9 @@ plotCoregulationProfileSpatial <- function(pathway,
                                            title=NULL,
                                            assay=DefaultAssay(object),
                                            colors=c("darkblue", "lightgrey", "darkred"),
-                                           guide="colourbar", ...) {
+                                           guide="colourbar",
+                                           image.alpha = 0,
+                                           ...) {
     stopifnot(requireNamespace("Seurat"))
     # TODO duplicated code with plotCoregulationProfileReduction
     if (is.list(pathway)) {
@@ -286,6 +288,7 @@ plotCoregulationProfileSpatial <- function(pathway,
                                            title = titles[i],
                                            assay = assay,
                                            colors = colors,
+                                           image.alpha = image.alpha,
                                            ...))
         names(ps) <- names(pathway)
         ps <- unlist(ps, recursive = FALSE)
@@ -296,7 +299,7 @@ plotCoregulationProfileSpatial <- function(pathway,
     obj2 <- addGesecaScores(list(pathway = pathway), object,
                                     assay = assay, scale = TRUE)
     ps <- Seurat::SpatialFeaturePlot(obj2, features = "pathway",
-                                     combine = FALSE, image.alpha = 0, ...)
+                                     combine = FALSE, image.alpha = image.alpha, ...)
     # suppress message of replacing existing color palette
     suppressMessages(ps <- lapply(ps, function(p){
         res <- p + scale_fill_gradientn(limits = c(-3, 3),

--- a/R/geseca-plot.R
+++ b/R/geseca-plot.R
@@ -47,9 +47,9 @@ plotCoregulationProfile <- function(pathway, E,
         geom_point(alpha = 0.1) +
         geom_path(alpha = 0.2) +
         geom_line(data = pointDt, aes(x = x, y = y),
-                  group = "mean", color = "#13242a", size = 1.5) +
-        geom_hline(yintercept = min(pointDt$y), color = "#495057", linetype = "dashed", size = 1) +
-        geom_hline(yintercept = max(pointDt$y), color = "#495057", linetype = "dashed", size = 1) +
+                  group = "mean", color = "#13242a", linewidth = 1.5) +
+        geom_hline(yintercept = min(pointDt$y), color = "#495057", linetype = "dashed", linewidth = 1) +
+        geom_hline(yintercept = max(pointDt$y), color = "#495057", linetype = "dashed", linewidth = 1) +
         (if (!is.null(conditions)) {
             geom_point(shape=21, size=4,
                        data = pointDt,

--- a/R/geseca-plot.R
+++ b/R/geseca-plot.R
@@ -254,6 +254,7 @@ plotGesecaTable <- function(gesecaRes,
 #' @param colors vector of three colors to use in the color scheme
 #' @param guide option for `ggplot2::scale_color_gradientn` to control for presence of the color legend
 #' the same universe of genes in the scaled data
+#' @param image.alpha adjust the opacity of the background images
 #' @param ... optional arguments for \link[Seurat]{SpatialFeaturePlot}
 #' @return ggplot object (or a list of objects) with the coregulation profile plot
 #'

--- a/R/plot.R
+++ b/R/plot.R
@@ -94,7 +94,7 @@ plotGseaTable <- function(pathways, stats, fgseaRes,
             ggplot() +
                 geom_segment(aes(x=p, xend=p,
                                  y=0, yend=statsAdj[p]),
-                             size=0.2) +
+                             linewidth=0.2) +
                 scale_x_continuous(limits=c(0, length(statsAdj)),
                                    expand=c(0, 0)) +
                 scale_y_continuous(limits=c(-1, 1),

--- a/man/plotCoregulationProfileSpatial.Rd
+++ b/man/plotCoregulationProfileSpatial.Rd
@@ -11,6 +11,7 @@ plotCoregulationProfileSpatial(
   assay = DefaultAssay(object),
   colors = c("darkblue", "lightgrey", "darkred"),
   guide = "colourbar",
+  image.alpha = 0,
   ...
 )
 }
@@ -28,6 +29,8 @@ the same universe of genes in the scaled data}
 
 \item{guide}{option for `ggplot2::scale_color_gradientn` to control for presence of the color legend
 the same universe of genes in the scaled data}
+
+\item{image.alpha}{adjust the opacity of the background images}
 
 \item{...}{optional arguments for \link[Seurat]{SpatialFeaturePlot}}
 }

--- a/man/plotCoregulationProfileSpatial.Rd
+++ b/man/plotCoregulationProfileSpatial.Rd
@@ -10,7 +10,8 @@ plotCoregulationProfileSpatial(
   title = NULL,
   assay = DefaultAssay(object),
   colors = c("darkblue", "lightgrey", "darkred"),
-  guide = "colourbar"
+  guide = "colourbar",
+  ...
 )
 }
 \arguments{
@@ -27,6 +28,8 @@ the same universe of genes in the scaled data}
 
 \item{guide}{option for `ggplot2::scale_color_gradientn` to control for presence of the color legend
 the same universe of genes in the scaled data}
+
+\item{...}{optional arguments for \link[Seurat]{SpatialFeaturePlot}}
 }
 \value{
 ggplot object (or a list of objects) with the coregulation profile plot

--- a/vignettes/fgsea-tutorial.Rmd
+++ b/vignettes/fgsea-tutorial.Rmd
@@ -175,3 +175,9 @@ bg <- names(exampleRanks)
 foraRes <- fora(genes=fg, universe=bg, pathways=examplePathways)
 head(foraRes)
 ```
+
+## Session info
+
+```{r}
+sessionInfo()
+```

--- a/vignettes/geseca-tutorial.Rmd
+++ b/vignettes/geseca-tutorial.Rmd
@@ -349,8 +349,20 @@ Finally, let us plot spatial expression of the top four pathways:
 topPathways <- gesecaRes[, pathway] |> head(4)
 titles <- sub("HALLMARK_", "", topPathways)
 
+pt.size.factor <- 1.6
+
+
+# Starting from Seurat version 5.1.0, the scaling method for spatial plots was changed.
+# As mentioned here: https://github.com/satijalab/seurat/issues/9049
+# This code provides a workaround to adapt to the new scaling behavior.
+if (packageVersion("Seurat") >= "5.1.0"){
+    sfactors <- ScaleFactors(obj@images$slice1)
+    pt.size.factor <- 1.5 * sfactors$fiducial / sfactors$hires
+}
+
 ps <- plotCoregulationProfileSpatial(pathways[topPathways], obj,
-                                       title=titles)
+                                     title=titles, 
+                                     pt.size.factor=pt.size.factor)
 cowplot::plot_grid(plotlist=ps, ncol=2)
 ```
 
@@ -363,8 +375,15 @@ is more characteristic to the "normal" tissue region:
 ```{r fig.width=5, fig.height=3.5, out.width="50%"}
 plotCoregulationProfileSpatial(pathways$HALLMARK_OXIDATIVE_PHOSPHORYLATION,
                                obj,
-                               title=sprintf("HALLMARK_OXIDATIVE_PHOSPHORYLATION (pval=%.2g)",
+                               pt.size.factor=pt.size.factor,
+                               title=sprintf("HALLMARK_OXIDATIVE_PHOSPHORYLATION\n(pval=%.2g)",
                                              gesecaRes[
                                                  match("HALLMARK_OXIDATIVE_PHOSPHORYLATION", pathway),
                                                  pval]))
+```
+
+## Session info
+
+```{r echo=TRUE}
+sessionInfo()
 ```


### PR DESCRIPTION
Adjusted the `plotCoregulationSpatial` function to support multiple samples, as outlined in issue #150.

I checked the refactored function with two example (code snippet is attached in the end).

I also added ellipsis (`...`) to allow passing extra arguments to `Seurat::SpatialFeaturePlot`. This should address some display issues with spatial data that users have encountered after upgrading to Seurat 5, as noted in [this issue](https://github.com/satijalab/seurat/issues/9049), by enabling manual adjustment of `pt.size.factor`.


```R
library(fgsea)
library(Seurat)
library(SeuratData)
library(ggplot2)
library(patchwork)
library(dplyr)
library(msigdbr)

# ----------------------------------------------------------------------------------------------------------------
# Example From Seurat vignette
# ----------------------------------------------------------------------------------------------------------------


InstallData("stxBrain")

brain <- LoadData("stxBrain", type = "anterior1")



brain <- SCTransform(brain, assay = "Spatial", verbose = FALSE)

brain2 <- LoadData("stxBrain", type = "posterior1")
brain2 <- SCTransform(brain2, assay = "Spatial", verbose = FALSE)

brain.merge <- merge(brain, brain2)

DefaultAssay(brain.merge) <- "SCT"
VariableFeatures(brain.merge) <- c(VariableFeatures(brain), VariableFeatures(brain2))
brain.merge <- RunPCA(brain.merge, verbose = FALSE)
brain.merge <- FindNeighbors(brain.merge, dims = 1:30)
brain.merge <- FindClusters(brain.merge, verbose = FALSE)
brain.merge <- RunUMAP(brain.merge, dims = 1:30)


brain.merge <- RunPCA(brain.merge, assay = "SCT", verbose = FALSE,
                      rev.pca = TRUE, reduction.name = "pca.rev",
                      reduction.key="PCR_", npcs = 50)

E <- brain.merge@reductions$pca.rev@feature.loadings


pathwaysDF <- msigdbr("mouse", category="H")
pathways <- split(pathwaysDF$gene_symbol, pathwaysDF$gs_name)

set.seed(1)
gesecaRes <- geseca(pathways, E, minSize = 15, maxSize = 500, center = FALSE)


topPathways <- gesecaRes[, pathway] |> head(4)
titles <- sub("HALLMARK_", "", topPathways)



ps <- plotCoregulationProfileSpatial(pathways[topPathways], 
                                     brain.merge, 
                                     title=titles,
                                     pt.size.factor=2.5,
                                     stroke=0.1)

ps <- lapply(ps, function(p) p + theme_minimal(base_size = 6))
ps <- cowplot::plot_grid(plotlist = ps, ncol=2)
ps


# ----------------------------------------------------------------------------------------------------------------
# Example From GESECA vignette
# ----------------------------------------------------------------------------------------------------------------
obj <- readRDS(url("https://alserglab.wustl.edu/files/fgsea/275_T_seurat.rds"))
obj <- UpdateSeuratObject(obj)


obj <- SCTransform(obj, assay = "Spatial", verbose = FALSE, variable.features.n = 10000)

obj <- RunPCA(obj, assay = "SCT", verbose = FALSE,
              rev.pca = TRUE, reduction.name = "pca.rev",
              reduction.key="PCR_", npcs = 50)

E <- obj@reductions$pca.rev@feature.loadings

pathwaysDF <- msigdbr("human", category="H")
pathways <- split(pathwaysDF$gene_symbol, pathwaysDF$gs_name)

set.seed(1)
gesecaRes <- geseca(pathways, E, minSize = 15, maxSize = 500, center = FALSE)

topPathways <- gesecaRes[, pathway] |> head(4)
titles <- sub("HALLMARK_", "", topPathways)

sfactors <- ScaleFactors(obj@images$slice1)
psf <- 1.5 * sfactors$fiducial / sfactors$hires

ps <- plotCoregulationProfileSpatial(pathways[topPathways], obj,
                                     title=titles, 
                                     pt.size.factor=psf,
                                     stroke=0.2)
cowplot::plot_grid(plotlist=ps, ncol=2)
```