### PR TITLE
Unify single-pathway simple permutations

### DIFF
--- a/R/fgsea.R
+++ b/R/fgsea.R
@@ -224,7 +224,6 @@ calcGseaStat <- function(stats,
 #' data(examplePathways)
 #' data(exampleRanks)
 #' fgseaRes <- fgseaSimple(examplePathways, exampleRanks, nperm=10000, maxSize=500)
-#' # Testing only one pathway is implemented in a more efficient manner
 #' fgseaRes1 <- fgseaSimple(examplePathways[1], exampleRanks, nperm=10000)
 fgseaSimple <- function(pathways,
                         stats,
@@ -617,9 +616,6 @@ fgseaSimpleImpl <- function(pathwayScores, pathwaysSizes,
                             pathwaysFiltered, leadingEdges,
                             permPerProc, seeds,toKeepLength,
                             stats, BPPARAM, scoreType){
-    K <- max(pathwaysSizes)
-    universe <- seq_along(stats)
-
     counts <- bplapply(seq_along(permPerProc), function(i) {
         nperm1 <- permPerProc[i]
         leEs <- rep(0, toKeepLength)
@@ -628,38 +624,20 @@ fgseaSimpleImpl <- function(pathwayScores, pathwaysSizes,
         geZero <- rep(0, toKeepLength)
         leZeroSum <- rep(0, toKeepLength)
         geZeroSum <- rep(0, toKeepLength)
-        if (toKeepLength == 1) {
-            set.seed(seeds[i])
-            for (j in seq_len(nperm1)) {
-                randSample <- sample.int(length(universe), K)
-                randEsP <- calcGseaStat(
-                    stats = stats,
-                    selectedStats = randSample,
-                    gseaParam = 1,
-                    scoreType = scoreType)
-                leEs <- leEs + (randEsP <= pathwayScores)
-                geEs <- geEs + (randEsP >= pathwayScores)
-                leZero <- leZero + (randEsP <= 0)
-                geZero <- geZero + (randEsP >= 0)
-                leZeroSum <- leZeroSum + pmin(randEsP, 0)
-                geZeroSum <- geZeroSum + pmax(randEsP, 0)
-            }
-        } else {
-            aux <- calcGseaStatCumulativeBatch(
-                stats = stats,
-                gseaParam = 1,
-                pathwayScores = pathwayScores,
-                pathwaysSizes = pathwaysSizes,
-                iterations = nperm1,
-                seed = seeds[i],
-                scoreType = scoreType)
-            leEs = get("leEs", aux)
-            geEs = get("geEs", aux)
-            leZero = get("leZero", aux)
-            geZero = get("geZero", aux)
-            leZeroSum = get("leZeroSum", aux)
-            geZeroSum = get("geZeroSum", aux)
-        }
+        aux <- calcGseaStatCumulativeBatch(
+            stats = stats,
+            gseaParam = 1,
+            pathwayScores = pathwayScores,
+            pathwaysSizes = pathwaysSizes,
+            iterations = nperm1,
+            seed = seeds[i],
+            scoreType = scoreType)
+        leEs = get("leEs", aux)
+        geEs = get("geEs", aux)
+        leZero = get("leZero", aux)
+        geZero = get("geZero", aux)
+        leZeroSum = get("leZeroSum", aux)
+        geZeroSum = get("geZeroSum", aux)
         data.table(pathway=seq_len(toKeepLength),
                    leEs=leEs, geEs=geEs,
                    leZero=leZero, geZero=geZero,
@@ -737,7 +715,5 @@ setUpBPPARAM <- function(nproc=0, BPPARAM=NULL){
         return(BPPARAM)
     }
 }
-
-
 
 

--- a/tests/testthat/test_gsea_multilevel.R
+++ b/tests/testthat/test_gsea_multilevel.R
@@ -228,6 +228,83 @@ test_that("fgseaSimpleImpl works correctly in fgseaMultilevel", {
     expect_equal(pval1, pval2)
 })
 
+test_that("fgseaSimpleImpl is reproducible for a single pathway", {
+    stats <- setNames(c(5, 4, 3, 2, 1, -1, -2, -3, -4, -5), paste0("g", 1:10))
+    pathways1 <- list(p1 = c("g1", "g4", "g7"))
+    pathways2 <- list(p1 = c("g1", "g4", "g7"),
+                      p2 = c("g2", "g5", "g8"))
+
+    pp1 <- fgsea:::preparePathwaysAndStats(pathways1, stats, 1, length(stats) - 1, 1, "std")
+    pp2 <- fgsea:::preparePathwaysAndStats(pathways2, stats, 1, length(stats) - 1, 1, "std")
+
+    gseaStatRes1 <- do.call(rbind,
+                            lapply(pp1$filtered, fgsea:::calcGseaStat,
+                                   stats = pp1$stats,
+                                   returnLeadingEdge = TRUE,
+                                   scoreType = "std"))
+    gseaStatRes2 <- do.call(rbind,
+                            lapply(pp2$filtered, fgsea:::calcGseaStat,
+                                   stats = pp2$stats,
+                                   returnLeadingEdge = TRUE,
+                                   scoreType = "std"))
+
+    set.seed(123)
+    seeds <- sample.int(1e9, 1)
+
+    singleRes <- fgsea:::fgseaSimpleImpl(
+        pathwayScores = unlist(gseaStatRes1[, "res"]),
+        pathwaysSizes = pp1$sizes,
+        pathwaysFiltered = pp1$filtered,
+        leadingEdges = mapply("[", list(names(pp1$stats)),
+                              gseaStatRes1[, "leadingEdge"], SIMPLIFY = FALSE),
+        permPerProc = 1000,
+        seeds = seeds,
+        toKeepLength = 1,
+        stats = pp1$stats,
+        BPPARAM = SerialParam(),
+        scoreType = "std"
+    )
+
+    batchRes <- fgsea:::fgseaSimpleImpl(
+        pathwayScores = unlist(gseaStatRes2[, "res"]),
+        pathwaysSizes = pp2$sizes,
+        pathwaysFiltered = pp2$filtered,
+        leadingEdges = mapply("[", list(names(pp2$stats)),
+                              gseaStatRes2[, "leadingEdge"], SIMPLIFY = FALSE),
+        permPerProc = 1000,
+        seeds = seeds,
+        toKeepLength = 2,
+        stats = pp2$stats,
+        BPPARAM = SerialParam(),
+        scoreType = "std"
+    )
+
+    expect_equal(singleRes[, .(ES, NES, pval, nMoreExtreme)],
+                 batchRes[pathway == "p1", .(ES, NES, pval, nMoreExtreme)])
+})
+
+test_that("fgseaMultilevel simple stage matches between single and batch inputs", {
+    stats <- setNames(c(5, 4, 3, 2, 1, -1, -2, -3, -4, -5), paste0("g", 1:10))
+    pathways1 <- list(p1 = c("g1", "g4", "g7"))
+    pathways2 <- list(p1 = c("g1", "g4", "g7"),
+                      p2 = c("g2", "g5", "g8"))
+
+    set.seed(42)
+    singleRes <- fgseaMultilevel(pathways1, stats,
+                                 nPermSimple = 1000,
+                                 sampleSize = 101,
+                                 eps = 1e-10)
+
+    set.seed(42)
+    batchRes <- fgseaMultilevel(pathways2, stats,
+                                nPermSimple = 1000,
+                                sampleSize = 101,
+                                eps = 1e-10)
+
+    expect_equal(singleRes[, .(ES, NES, pval)],
+                 batchRes[pathway == "p1", .(ES, NES, pval)])
+})
+
 test_that("fgsea throws a warning when reaching eps", {
     data(examplePathways)
     data(exampleRanks)


### PR DESCRIPTION
fgseaMultilevel() currently behaves differently in the simple permutation stage depending on how many pathways are retained. If only one pathway remains, fgseaSimpleImpl() takes a special R-level path, while the usual case goes through the seeded C++ batch helper.

In practice this means the same pathway, stats, seed, nPermSimple, sampleSize, and eps can produce identical ES but different NES/pval depending only on whether the pathway is run alone or together with another retained pathway. The single-pathway branch uses R-level sample.int() inside bplapply(..., SerialParam()), where RNGkind() becomes L'Ecuyer-CMRG, while the normal batch path uses its own seeded C++ RNG.

This patch removes the single-pathway special case and routes all simple-stage permutations through calcGseaStatCumulativeBatch(). That makes the single-pathway case consistent with the normal batch path without changing the broader multilevel logic.

Added tests cover:
1) fgseaSimpleImpl() parity between single-pathway and batch-path execution
2) fgseaMultilevel() parity when the same pathway is run alone vs alongside another retained pathway under a fixed seed